### PR TITLE
Decorate logger with redactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ An easy way to bootstrap your application with batteries included.
 ## What is included?
 - Pairs well with [cobra](github.com/spf13/cobra) and [viper](github.com/spf13/viper) via [fangs](github.com/anchore/fangs), covering CLI arg parsing and config file + env var loading.
 - Provides an event bus via [partybus](github.com/wagoodman/go-partybus), enabling visibility deep in your execution stack as to what is happening.
-- Provides a logger via the [logger interface](github.com/anchore/go-logger), allowing you to swap out for any concrete logger you want and decorate with redaction capabilities.
+- Provides a logger via the [logger interface](github.com/anchore/go-logger), allowing you to swap out for any concrete logger you'd like.
+- Supplies a redactor object that can be used to remove sensitive output before it's exposed (in the log or elsewhere).
 - Defines a generic UI interface that adapts well to TUI frameworks such as [bubbletea](github.com/charmbracelet/bubbletea).
 
 ## Example

--- a/application_test.go
+++ b/application_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anchore/fangs"
 	"github.com/anchore/go-logger"
 	"github.com/anchore/go-logger/adapter/discard"
+	"github.com/anchore/go-logger/adapter/redact"
 )
 
 const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
@@ -153,7 +154,7 @@ func Test_Application_Setup_PassLoggerConstructor(t *testing.T) {
 
 	cfg := NewSetupConfig(Identification{Name: name, Version: version}).
 		WithUI(&mockUI{}).
-		WithLoggerConstructor(func(config Config) (logger.Logger, error) {
+		WithLoggerConstructor(func(_ Config, _ redact.Store) (logger.Logger, error) {
 			return newMockLogger(), nil
 		})
 

--- a/logging.go
+++ b/logging.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anchore/go-logger"
 	"github.com/anchore/go-logger/adapter/discard"
 	"github.com/anchore/go-logger/adapter/logrus"
+	"github.com/anchore/go-logger/adapter/redact"
 )
 
 type terminalDetector interface {
@@ -28,9 +29,9 @@ func (s stockTerminalDetector) StderrIsTerminal() bool {
 	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 
-type LoggerConstructor func(Config) (logger.Logger, error)
+type LoggerConstructor func(Config, redact.Store) (logger.Logger, error)
 
-func DefaultLogger(clioCfg Config) (logger.Logger, error) {
+func DefaultLogger(clioCfg Config, store redact.Store) (logger.Logger, error) {
 	cfg := clioCfg.Log
 	if cfg == nil {
 		return discard.New(), nil
@@ -45,6 +46,10 @@ func DefaultLogger(clioCfg Config) (logger.Logger, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if store != nil {
+		l = redact.New(l, store)
 	}
 
 	return l, nil

--- a/setup_config.go
+++ b/setup_config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/anchore/fangs"
 	"github.com/anchore/go-logger"
 	"github.com/anchore/go-logger/adapter/discard"
+	"github.com/anchore/go-logger/adapter/redact"
 )
 
 type SetupConfig struct {
@@ -85,7 +86,7 @@ func (c *SetupConfig) WithLoggingConfig(cfg LoggingConfig) *SetupConfig {
 
 func (c *SetupConfig) WithNoLogging() *SetupConfig {
 	c.DefaultLoggingConfig = nil
-	c.LoggerConstructor = func(config Config) (logger.Logger, error) {
+	c.LoggerConstructor = func(_ Config, _ redact.Store) (logger.Logger, error) {
 		return discard.New(), nil
 	}
 	return c

--- a/state.go
+++ b/state.go
@@ -45,7 +45,7 @@ func (s *State) setupLogger(cx LoggerConstructor) error {
 		cx = DefaultLogger
 	}
 
-	lgr, err := cx(s.Config)
+	lgr, err := cx(s.Config, s.RedactStore)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Since we've moved the redaction store to clio it can automagically handle applying that redactor to the standard logger created. This also allows someone to craft their own logger with that same redactor store via the log constructor.