### PR TITLE
Add exit event

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,0 +1,21 @@
+package clio
+
+import (
+	"os"
+
+	"github.com/wagoodman/go-partybus"
+)
+
+const ExitEventType partybus.EventType = "clio-exit"
+
+func ExitEvent(interrupt bool) partybus.Event {
+	if interrupt {
+		return partybus.Event{
+			Type:  ExitEventType,
+			Value: os.Interrupt,
+		}
+	}
+	return partybus.Event{
+		Type: ExitEventType,
+	}
+}


### PR DESCRIPTION
This PR introduces the concept of a common Exit event that consuming applications can use to gracefully exit the application or forcefully interrupt the event loop. Up to this point clio has been an observer and not a participant in the bus, however, there are a couple of reasons why that needs to change for the use case of graceful shutdown:

1. If the consuming application is using a TUI framework that puts the terminal into raw mode then we cannot depend on the signal handlers in cases when a Keyboard Interrupt was given, since this mode prevents control characters from being interpreted as signals (e.g. ctrl+c). This means there needs to be an in-process way to let the event loop know that a graceful shutdown is needed. The event bus is the perfect use case for this the event loop is already wired into it.

2. automatically allowing clio to handle when to send an exit when a cobra command is done executing makes bus management simpler for the user.

A consequence of this is that consuming applications need to replace their existing exit events for this common exit event and it is important that library code to not use these events or else risk confusing library consumers (e.g. why did my application randomly exit when I imported this library? [because the exit event was sent from the lib code intended for another entrypoint altogether]).