### PR TITLE
Add ApplicationBuilder interface

### DIFF
--- a/application.go
+++ b/application.go
@@ -57,6 +57,10 @@ func (a *application) ID() Identification {
 	return a.setupConfig.ID
 }
 
+func (a *application) RootCommand() *cobra.Command {
+	return a.root
+}
+
 // State returns all application configuration and resources to be either used or replaced by the caller. Note: this is only valid after the application has been setup (cobra PreRunE has run).
 func (a *application) State() *State {
 	return &a.state

--- a/application.go
+++ b/application.go
@@ -27,10 +27,15 @@ type postConstruct func(*application)
 
 type Application interface {
 	ID() Identification
+	RootCommand() *cobra.Command
+	Run()
+}
+
+type ApplicationBuilder interface {
+	Application
 	AddFlags(flags *pflag.FlagSet, cfgs ...any)
 	SetupCommand(cmd *cobra.Command, cfgs ...any) *cobra.Command
 	SetupRootCommand(cmd *cobra.Command, cfgs ...any) *cobra.Command
-	Run()
 }
 
 type application struct {
@@ -44,7 +49,7 @@ var _ interface {
 	fangs.PostLoader
 } = (*application)(nil)
 
-func New(cfg SetupConfig) Application {
+func New(cfg SetupConfig) ApplicationBuilder {
 	return &application{
 		setupConfig: cfg,
 		state: State{


### PR DESCRIPTION
This adds an `ApplicationBuilder` interface to allow consuming applications to separate building and usage concerns. Whlie the CLI is being built, add flag concerns and command additions are allowed, but once the application is built the consumer application can decide to raise up the user interface to either run the application or embed it into an existing CLI.