### PR TITLE
chore: use provided writer for version command

### DIFF
--- a/version.go
+++ b/version.go
@@ -46,7 +46,7 @@ func VersionCommand(id Identification, additions ...versionAddition) *cobra.Comm
 
 			value, err := versionInfo(info, format, additions...)
 			if err == nil {
-				fmt.Print(value)
+				cmd.Print(value)
 			}
 			return err
 		},


### PR DESCRIPTION
This PR adjusts usage of implicit `os.Stdout` to instead use the output stream provided to Cobra with `cmd.Print`