### PR TITLE
fix: remove panic case from conflicting configs

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -127,7 +127,7 @@ func Test_Application_Setup_WiresFangs(t *testing.T) {
 
 	app := New(*cfg)
 
-	cmd := app.SetupRootCommand(&cobra.Command{
+	cmd, _ := app.SetupRootCommand(&cobra.Command{
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -163,7 +163,7 @@ func Test_Application_Setup_PassLoggerConstructor(t *testing.T) {
 
 	app := New(*cfg)
 
-	cmd := app.SetupRootCommand(&cobra.Command{
+	cmd, _ := app.SetupRootCommand(&cobra.Command{
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		Run:                func(cmd *cobra.Command, args []string) {},
@@ -192,7 +192,7 @@ func Test_Application_Setup_ConfigureLogger(t *testing.T) {
 
 	app := New(*cfg)
 
-	cmd := app.SetupRootCommand(&cobra.Command{
+	cmd, _ := app.SetupRootCommand(&cobra.Command{
 		DisableFlagParsing: true,
 		Args:               cobra.ArbitraryArgs,
 		Run:                func(cmd *cobra.Command, args []string) {},
@@ -280,7 +280,7 @@ func Test_SetupCommand(t *testing.T) {
 
 	app := New(*cfg)
 
-	root := app.SetupRootCommand(&cobra.Command{})
+	root, _ := app.SetupRootCommand(&cobra.Command{})
 
 	app.AddFlags(root.PersistentFlags(), p)
 

--- a/cliotestutils/application.go
+++ b/cliotestutils/application.go
@@ -58,12 +58,12 @@ func (a *testApplication) SetupCommand(cmd *cobra.Command, cfgs ...any) *cobra.C
 	return a.Application.SetupCommand(cmd, cfgs...)
 }
 
-func (a *testApplication) SetupRootCommand(cmd *cobra.Command, cfgs ...any) *cobra.Command {
+func (a *testApplication) SetupRootCommand(cmd *cobra.Command, cfgs ...any) (*cobra.Command, error) {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		a.assertion(cmd, args, cfgs...)
 		return nil
 	}
-	return a.Application.SetupRootCommand(cmd, cfgs...)
+	return a.Application.SetupRootCommand(cmd, cfgs...), nil
 }
 
 /*

--- a/help_template_test.go
+++ b/help_template_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/anchore/go-logger/adapter/redact"
 )
 
+func Test_showConfigInRootHelp(t *testing.T) {
+	cfg := NewSetupConfig(Identification{
+		Name:    "app",
+		Version: "1.2.3",
+	}).
+		WithConfigInRootHelp().
+		WithGlobalConfigFlag()
+}
+
 func Test_redactingHelpText(t *testing.T) {
 	cfg := NewSetupConfig(Identification{
 		Name:    "app",
@@ -27,7 +36,7 @@ func Test_redactingHelpText(t *testing.T) {
 
 	app := New(*cfg)
 
-	root := app.SetupRootCommand(&cobra.Command{}, r)
+	root, _ := app.SetupRootCommand(&cobra.Command{}, r)
 
 	r.store = app.(*application).state.RedactStore
 

--- a/setup_config.go
+++ b/setup_config.go
@@ -110,15 +110,17 @@ func (c *SetupConfig) withPostConstructs(postConstructs ...postConstruct) *Setup
 
 // WithGlobalConfigFlag adds the global `-c` / `--config` flags to the root command
 func (c *SetupConfig) WithGlobalConfigFlag() *SetupConfig {
-	return c.withPostConstructs(func(a *application) {
+	return c.withPostConstructs(func(a *application) error {
 		a.AddFlags(a.root.PersistentFlags(), &a.setupConfig.FangsConfig)
+		return nil
 	})
 }
 
 // WithGlobalLoggingFlags adds the global logging flags to the root command.
 func (c *SetupConfig) WithGlobalLoggingFlags() *SetupConfig {
-	return c.withPostConstructs(func(a *application) {
+	return c.withPostConstructs(func(a *application) error {
 		a.AddFlags(a.root.PersistentFlags(), &a.state.Config)
+		return nil
 	})
 }
 


### PR DESCRIPTION
## Summary

This attempts to remove the panic config case for tools that consume clio. When a user has an older version of a config, but is running the help command for a newer version of the tool, the fangs load fails and a panic case was triggered.

This fix updates clio to populate the error case up to the eventual caller: `app.SetupRootCommand`

This allows the different consumer libraries to assert on if an error was found when attempting to setup the root command and report on the config failure. Here is an example of syft using this branch to show the error when latest uses an older config structure:

<img width="1499" alt="Screenshot 2024-02-05 at 11 24 00 AM" src="https://github.com/anchore/clio/assets/32073428/82f1c91b-c565-4fab-93a7-15f140731612">