### PR TITLE
fix: output version to stdout instead of command out

### DIFF
--- a/version.go
+++ b/version.go
@@ -46,7 +46,7 @@ func VersionCommand(id Identification, additions ...versionAddition) *cobra.Comm
 
 			value, err := versionInfo(info, format, additions...)
 			if err == nil {
-				cmd.Print(value)
+				fmt.Print(value)
 			}
 			return err
 		},

--- a/version_test.go
+++ b/version_test.go
@@ -1,10 +1,38 @@
 package clio
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func Test_versionOutputToStdout(t *testing.T) {
+	c := VersionCommand(Identification{
+		Name:    "test",
+		Version: "version",
+	})
+
+	stdout := &bytes.Buffer{}
+	restoreStdout := capture(&os.Stdout, stdout, 1024)
+	defer restoreStdout()
+
+	stderr := &bytes.Buffer{}
+	restoreStderr := capture(&os.Stderr, stderr, 1024)
+	defer restoreStderr()
+
+	_ = c.RunE(c, nil)
+
+	// close and flush the buffers, wait until complete
+	restoreStdout()
+	restoreStderr()
+
+	require.NotEmpty(t, stdout.String())
+	require.Empty(t, stderr.String())
+}
 
 func Test_versionInfoText(t *testing.T) {
 	expected := `Application:               the-name
@@ -66,4 +94,38 @@ func Test_versionInfoJSON(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.JSONEq(t, expected, got)
+}
+
+func capture(target **os.File, writer io.Writer, bufSize int) (close func()) {
+	original := *target
+
+	r, w, _ := os.Pipe()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, bufSize)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				_, _ = writer.Write(buf[0:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+	}()
+
+	*target = w
+
+	return func() {
+		if original != nil {
+			_ = w.Close()
+			wg.Wait()
+			*target = original
+			original = nil
+		}
+	}
 }


### PR DESCRIPTION
The Version command had been modified to output to the _command_ output, but this defaults to stderr, which is not what we want. This PR adjusts the behavior to always write to stdout (via `fmt.Print`)