### PR TITLE
Fix: still warn on zero verbosity

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -41,7 +41,7 @@ func DefaultLogger(clioCfg Config, store redact.Store) (logger.Logger, error) {
 
 	l, err := logrus.New(
 		logrus.Config{
-			EnableConsole: cfg.Verbosity > 0 && !cfg.Quiet,
+			EnableConsole: !cfg.Quiet,
 			FileLocation:  cfg.FileLocation,
 			Level:         cfg.Level,
 			Formatter:     adaptLogFormatter(logrus.DefaultTextFormatter()),

--- a/logging.go
+++ b/logging.go
@@ -163,6 +163,10 @@ func (l *LoggingConfig) selectLevel() (logger.Level, error) {
 }
 
 func (l *LoggingConfig) AllowUI(stdin fs.File) bool {
+	if forceNoTTY(os.Getenv("NO_TTY")) {
+		return false
+	}
+
 	pipedInput, err := isPipedInput(stdin)
 	if err != nil || pipedInput {
 		// since we can't tell if there was piped input we assume that there could be to disable the ETUI
@@ -186,6 +190,16 @@ func (l *LoggingConfig) AllowUI(stdin fs.File) bool {
 	}
 
 	return l.Verbosity == 0
+}
+
+func forceNoTTY(noTTYenvVar string) bool {
+	switch strings.ToLower(noTTYenvVar) {
+	case "1":
+		return true
+	case "true":
+		return true
+	}
+	return false
 }
 
 // isPipedInput returns true if there is no input device, which means the user **may** be providing input via a pipe.

--- a/logging_test.go
+++ b/logging_test.go
@@ -258,6 +258,26 @@ func TestLoggingConfig_AllowUI(t *testing.T) {
 	}
 }
 
+func TestForceNoTTY(t *testing.T) {
+	tests := []struct {
+		envVarValue string
+		want        bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"other-string", false},
+		{"1", true},
+		{"true", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.envVarValue, func(t *testing.T) {
+			assert.Equal(t, tt.want, forceNoTTY(tt.envVarValue))
+		})
+	}
+}
+
 func Test_isPipedInput(t *testing.T) {
 
 	tests := []struct {

--- a/logging_test.go
+++ b/logging_test.go
@@ -83,6 +83,19 @@ func Test_newLogger(t *testing.T) {
 				assert.Equal(t, "[0000]  INFO test *******\n", stripAnsi(buf.String()))
 			},
 		},
+		{
+			name: "warn logging is not discarded",
+			cfg:  &LoggingConfig{Level: "warn"},
+			assertLogger: func(log logger.Logger) {
+				c, ok := log.(logger.Controller)
+				require.True(t, ok)
+				out := c.GetOutput()
+				// attempt to cast as *os.File, which will fail if output
+				// has defaulted to io.Discard
+				_, ok = out.(*os.File)
+				require.True(t, ok)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Relates to anchore/grype#2180 and anchore/syft#3081.

This PR makes 2 changes:

1. If no TTY is present, and neither `--verbose` nor `--quiet` is set, `log.Warn` should be written to stderr.
2. Allow the environment variables `NO_TTY` to be set to force disabling the fancy terminal UI even if a TTY is present.

Number 1 will fix the linked bugs in Syft and Grype when this change is pulled into those repositories. Number 2 might be implemented differently or even removed - it really exists to enable testing bugs like number 1.