### PR TITLE
feat: allow mapping cmd error to exit code

### DIFF
--- a/application.go
+++ b/application.go
@@ -25,6 +25,8 @@ type Initializer func(*State) error
 
 type PostRun func(*State, error)
 
+type MapExitCode func(error) int
+
 type postConstruct func(*application)
 
 type Application interface {
@@ -277,6 +279,9 @@ func (a *application) Run() {
 		a.handleExitError(err, os.Stderr)
 
 		exitCode = 1
+		if a.setupConfig.mapExitCode != nil {
+			exitCode = a.setupConfig.mapExitCode(err)
+		}
 	}
 }
 

--- a/setup_config.go
+++ b/setup_config.go
@@ -25,6 +25,7 @@ type SetupConfig struct {
 	Initializers      []Initializer
 	postConstructs    []postConstruct
 	postRuns          []PostRun
+	mapExitCode       MapExitCode
 }
 
 func NewSetupConfig(id Identification) *SetupConfig {
@@ -123,5 +124,10 @@ func (c *SetupConfig) WithGlobalLoggingFlags() *SetupConfig {
 }
 
 func (c *SetupConfig) WithConfigInRootHelp() *SetupConfig {
+	return c
+}
+
+func (c *SetupConfig) WithMapExitCode(mapExitCode MapExitCode) *SetupConfig {
+	c.mapExitCode = mapExitCode
 	return c
 }


### PR DESCRIPTION
Add type func `MapExitCode` that can be set on `SetupConfig` and used by `Application` to map the error returned from running the root cmd to an exit code.

This is the first PR in a series towards fixing: https://github.com/anchore/scan-action/issues/390.

Once merged, I can open a PR for grype to set a `MapExitCode` func to return a different exitcode when `grypeerr.ErrAboveSeverityThreshold` is seen, which will close: https://github.com/anchore/grype/issues/1922.