### PR TITLE
chore(deps): restore Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/clio
 
-go 1.26.2
+go 1.25.0
 
 require (
 	github.com/anchore/fangs v0.0.0-20250319155437-a26984174d7d


### PR DESCRIPTION
Restores the go directive in go.mod to 1.25.0 (pre-#205). Bumped in #205 (merge c63b2994e85aa61796ff842863cf0304f4bd6409).